### PR TITLE
Additional check before trimming public dir

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -228,7 +228,7 @@ class Assets extends Prefab {
 						&& is_file($path)) ? '?'.filemtime($path) : '';
 					$base = ($this->f3->get('ASSETS.prepend_base') && $asset['origin']!='external'
 						&& is_file($path)) ? $this->f3->get('BASE').'/': '';
-					if (isset($trimPublicDir))
+					if (isset($trimPublicDir) && $asset['origin']!='external')
 						$path = substr($path,strlen($trimPublicDir));
 					$asset['path'] = $base.$path.$mtime;
 				}


### PR DESCRIPTION
Additional check for external assets to prevent trimming path when ASSETS.trim_public_root = true:
Before:
```
<asset src="//code.jquery.com/ui/1.10.3/jquery-ui.js" slot="external"/>
<script charset="UTF-8" src="ery.com/ui/1.10.3/jquery-ui.js"></script>
```
After:
```
<asset src="//code.jquery.com/ui/1.10.3/jquery-ui.js" slot="external"/>
<script charset="UTF-8" src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
```