### PR TITLE
Fix PHP 8.4 compatibility: explicit nullable types

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -32,7 +32,7 @@ class Assets extends Prefab {
 	/** @var array */
 	protected $formatter;
 
-	public function __construct(\Template $template=NULL) {
+	public function __construct(?\Template $template=NULL) {
 		$this->template = $template ?: \Template::instance();
 		$f3 = $this->f3 = \Base::instance();
 		$minifyCompiler = function($fileName,$path) {
@@ -72,7 +72,7 @@ class Assets extends Prefab {
 			'prepend_base'=>false
 		);
 		// merge options with defaults
-		$f3->set('ASSETS',$f3->exists('ASSETS',$opt) ?
+		$f3->set('ASSETS',$f3->exists('ASSETS',$opt) && is_array($opt) ?
 			array_replace_recursive($opt_defaults,$opt) : $opt_defaults);
 		// propagate default public temp dir
 		if (!$f3->devoid('ASSETS.public_path')) {


### PR DESCRIPTION
- Change constructor parameter from implicit nullable to explicit ?\Template
- Add type check for $opt before array_replace_recursive() to prevent type 

## Problem:
```
Assets::__construct(): Implicitly marking parameter $template as nullable is deprecated, the explicit nullable type must be used instead
```